### PR TITLE
絵合わせギミックのファイルパス変更とタイトルのBGMのコードを再追加した。

### DIFF
--- a/TorahuruGame/Game/Game.cpp
+++ b/TorahuruGame/Game/Game.cpp
@@ -159,7 +159,7 @@ bool Game::Start()
 	TimerUI();
 	InitSky();
 	SetSutamina();
-	//PlayBGM();
+	PlayBGM();
 	m_modelRender.SetPosition(m_position);
 	// ゲームの読み込みが終わった後、画面を明るくする。
 	SetLoading();

--- a/TorahuruGame/Game/PuzzleCube.cpp
+++ b/TorahuruGame/Game/PuzzleCube.cpp
@@ -74,7 +74,7 @@ bool PuzzleCube::Start()
 	std::array<ModelRender*, 3> modelRenders = { &m_modelRender, &m_modelRender2, &m_modelRender3 };
 	for (auto& render : modelRenders) {
 		// ファイルを読み込む。
-		render->Init("Assets/modelData/stage3/gimmick/PuzzleCube.tkm");
+		render->Init("Assets/modelData/stage2/gimmick/PuzzleCube.tkm");
 		// 大きさを変更する。
 		render->SetScale(CUBE_SCALE);
 	}
@@ -82,7 +82,7 @@ bool PuzzleCube::Start()
 	std::array<ModelRender*, 3> modelRenders2 = { &m_modelRender4, &m_modelRender5, &m_modelRender6 };
 	for (auto& render2 : modelRenders2) {
 		// ファイルを読み込む。
-		render2->Init("Assets/modelData/stage3/gimmick/PuzzleCubeFoundation.tkm");
+		render2->Init("Assets/modelData/stage2/gimmick/PuzzleCubeFoundation.tkm");
 		// 大きさを変更する。
 		render2->SetScale(CUBE_SCALE);
 	}

--- a/TorahuruGame/Game/Title.cpp
+++ b/TorahuruGame/Game/Title.cpp
@@ -29,6 +29,15 @@ bool Title::Start() {
     // 効果音を読み込む。
     g_soundEngine->ResistWaveFileBank(1,"Assets/sound/wadaiko.wav");
     m_tips = FindGO<Tips>("tips");
+
+    // BGMを読み込む。
+    g_soundEngine->ResistWaveFileBank(3, "Assets/sound/titleBGM.wav");
+    // soundSourceを作成する
+    m_bgm = NewGO<SoundSource>(3);
+    m_bgm->Init(3);
+    // BGMをループさせる。
+    m_bgm->Play(true);
+
     return true;
 }
 
@@ -37,6 +46,8 @@ void Title::Update() {
     if (m_isWaitLoadOut) {
         if (!m_Loading->IsLoading()) {
             NewGO<Game>(0, "game");
+            // BGMを停止。
+            DeleteGO(m_bgm);
             // タイトルを削除。
             DeleteGO(this);
         }


### PR DESCRIPTION
コンフリクトの修正ミスで絵合わせギミックのファイルパスが間違った方になっていたので修正し、消えてしまっていたタイトルのBGMを再追加しました。